### PR TITLE
[DO NOT MERGE] test: validate APT latest with image PR #525

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,3 +1,5 @@
+# DO NOT MERGE: temporary integration test for fedora-createrepo-image PR #525.
+# Container cosign verification is intentionally removed in this dummy PR.
 name: Create Repo for RustDesk latest
 
 on:
@@ -31,28 +33,18 @@ defaults:
 
 jobs:
   verify:
-    name: Verify container
+    name: Resolve PR test container (DO NOT MERGE)
     runs-on: ubuntu-24.04-arm
     outputs:
       digest: ${{ steps.get-digest.outputs.digest }}
     steps:
-        - name: Install Cosign
-          uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
         - name: Get image digest
           id: get-digest
           run: |
-            DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)
+            set -euo pipefail
+            DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:pr-525)
             echo "Resolved digest: ${DIGEST}"
             echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-        - name: Verify
-          run: |
-            set -euo pipefail
-            cosign verify --rekor-url=https://rekor.sigstore.dev \
-            --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            ghcr.io/xlionjuan/fedora-createrepo-image@${{ steps.get-digest.outputs.digest }}
 
   prepare:
     name: Prepare


### PR DESCRIPTION
## DO NOT MERGE — temporary integration test

This draft PR exists only to test https://github.com/xlionjuan/fedora-createrepo-image/pull/525. Close it without merging after the test. Do not enable auto-merge or mark it ready for review.

- Resolve `ghcr.io/xlionjuan/fedora-createrepo-image:pr-525` once and keep downstream jobs pinned to that resolved digest.
- Temporarily remove container cosign installation and signature verification because this is a PR test image.
- Exercise the existing preparation and signing workflow on this same-repository PR.
- Keep the existing PR-event guards that skip GitHub Pages and Cloudflare R2 deployment. Generated test artifacts remain in the Actions run.

Upstream commit: e180c8d9695affa34b4f56c3c86e6b1a85e5ab18

Observed test-image digest: sha256:cd15a2545febae32b015799482478213033b6927237c0c5a96a57a2a81050af7

The tag can move if upstream PR #525 is updated; each run records the digest it resolves.

## Test focus

Confirm stable RustDesk and RustDesk Server DEB repackaging and aptly repository signing continue to work with GnuPG after the image adds Sequoia key import. Keep existing release selection, archive-keyring attestation verification, and all package/repository signing steps intact.

## Validation

YAML structure, unchanged downstream job definitions and PR deployment guards, changed-shell syntax/ShellCheck, and `git diff --check` passed. Full actionlint reports only the same pre-existing ShellCheck diagnostics as main. The integration result will come from this PR Actions run.
